### PR TITLE
fix: mark peer dependencies as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,14 @@
     "rxjs": "7",
     "tslib": "2"
   },
+  "peerDependenciesMeta": {
+    "quill-delta": {
+      "optional": true
+    },
+    "rxjs": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "arg": "^5.0.2",
     "hyperdyperid": "^1.2.0",


### PR DESCRIPTION
These are not needed to use some of `json-joy` i.e. `memfs` does not need them, and marking them as optional means that `npm` and `pnpm` users will not get them automatically.