### PR TITLE
Just stash all tsconfig here for easy reference.

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "benchmark": "^2.1.4",
-    "config-housekeeping": "https://github.com/streamich/housekeeping#3532d2abeac159315ddf403d70517859d079c801",
     "editing-traces": "https://github.com/streamich/editing-traces#6494020428530a6e382378b98d1d7e31334e2d7b",
     "fast-json-patch": "^3.1.1",
     "html-webpack-plugin": "^5.6.0",

--- a/tsconfig.housekeeping.json
+++ b/tsconfig.housekeeping.json
@@ -1,0 +1,46 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "Node",
+    "removeComments": false,
+    "noImplicitAny": true,
+    "allowJs": false,
+    "allowSyntheticDefaultImports": true,
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "importHelpers": true,
+    "pretty": true,
+    "sourceMap": true,
+    "strict": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmitHelpers": true,
+    "noEmitOnError": true,
+    "noErrorTruncation": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "declaration": true,
+    "downlevelIteration": true,
+    "isolatedModules": false,
+    "lib": ["es2018", "es2017", "esnext", "dom", "esnext.asynciterable"],
+    "outDir": "./lib"
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "lib",
+    "es6",
+    "es2020",
+    "esm",
+    "docs",
+    "README.md"
+  ],
+  "typedocOptions": {
+    "entryPoints": [
+      "src/index.ts"
+    ],
+    "out": "typedocs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/config-housekeeping/tsconfig.json",
+  "extends": "./tsconfig.housekeeping.json",
   "include": ["src"],
   "exclude": ["node_modules", "lib", "es6", "es2020", "esm", "docs", "README.md"],
   "typedocOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,11 +1652,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-"config-housekeeping@https://github.com/streamich/housekeeping#3532d2abeac159315ddf403d70517859d079c801":
-  version "0.0.0"
-  uid "3532d2abeac159315ddf403d70517859d079c801"
-  resolved "https://github.com/streamich/housekeeping#3532d2abeac159315ddf403d70517859d079c801"
-
 connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
@@ -1904,7 +1899,6 @@ dot-case@^3.0.4:
 
 "editing-traces@https://github.com/streamich/editing-traces#6494020428530a6e382378b98d1d7e31334e2d7b":
   version "0.0.0"
-  uid "6494020428530a6e382378b98d1d7e31334e2d7b"
   resolved "https://github.com/streamich/editing-traces#6494020428530a6e382378b98d1d7e31334e2d7b"
 
 ee-first@1.1.1:
@@ -3108,7 +3102,6 @@ jsesc@^3.0.2:
 
 "json-crdt-traces@https://github.com/streamich/json-crdt-traces#ec825401dc05cbb74b9e0b3c4d6527399f54d54d":
   version "0.0.1"
-  uid ec825401dc05cbb74b9e0b3c4d6527399f54d54d
   resolved "https://github.com/streamich/json-crdt-traces#ec825401dc05cbb74b9e0b3c4d6527399f54d54d"
 
 json-logic-js@^2.0.2:


### PR DESCRIPTION
Move referenced tsconfig from a github package -- https://raw.githubusercontent.com/streamich/housekeeping/refs/heads/master/tsconfig.json to a local file to just make things easier to grok at a glance. There is no point storing this in it's own repo. It just makes it harder and more tedious to figure out what's going on with the tsconfig. Besides the tsconfig repo has one file and one commit 7 months ago, and the package ref version locked anyway so ...