### PR TITLE
Fix a couple of bugs when str_ins+str_del are used with transform

### DIFF
--- a/src/json-patch-ot/__tests__/scenarios.spec.ts
+++ b/src/json-patch-ot/__tests__/scenarios.spec.ts
@@ -1039,6 +1039,24 @@ const groups: ScenarioGroup[] = [
       },
     ],
   },
+  {
+    name: 'str_ins x str_del (different paths)',
+    scenarios: [
+      {
+        name: 'Operations on different paths should not interfere.',
+        docStart: {
+          a: 'hello',
+          b: 'world',
+        },
+        user1: [{op: 'str_ins', path: '/a', pos: 0, str: 'X'}],
+        user2: [{op: 'str_del', path: '/b', pos: 0, str: 'wor'}],
+        docEnd: {
+          a: 'Xhello',
+          b: 'ld',
+        },
+      },
+    ],
+  },
   /*
   {
     name: 'move x replace',
@@ -1075,4 +1093,3 @@ for (const group of groups) {
     }
   });
 }
-

--- a/src/json-patch-ot/__tests__/scenarios.spec.ts
+++ b/src/json-patch-ot/__tests__/scenarios.spec.ts
@@ -1013,6 +1013,32 @@ const groups: ScenarioGroup[] = [
       },
     ],
   },
+  {
+    name: 'str_ins x str_del (same position)',
+    scenarios: [
+      {
+        name: 'Deletes at same position as insert.',
+        docStart: {a: 'abcde'},
+        user1: [{op: 'str_ins', path: '/a', pos: 0, str: 'X'}],
+        user2: [{op: 'str_del', path: '/a', pos: 0, str: 'abc'}],
+        docEnd: {a: 'Xde'},
+      },
+      {
+        name: 'Deletes at same non-zero position as insert.',
+        docStart: {a: '12abcde'},
+        user1: [{op: 'str_ins', path: '/a', pos: 2, str: 'X'}],
+        user2: [{op: 'str_del', path: '/a', pos: 2, str: 'abc'}],
+        docEnd: {a: '12Xde'},
+      },
+      {
+        name: 'Deletes at higher position than insert.',
+        docStart: {a: 'hello world'},
+        user1: [{op: 'str_ins', path: '/a', pos: 2, str: 'XX'}],
+        user2: [{op: 'str_del', path: '/a', pos: 8, str: 'rld'}],
+        docEnd: {a: 'heXXllo wo'},
+      },
+    ],
+  },
   /*
   {
     name: 'move x replace',
@@ -1049,3 +1075,4 @@ for (const group of groups) {
     }
   });
 }
+

--- a/src/json-patch-ot/transforms/xStrDel.ts
+++ b/src/json-patch-ot/transforms/xStrDel.ts
@@ -1,7 +1,9 @@
 import {type Op, OpStrDel, OpStrIns} from '../../json-patch/op';
+import {isPathEqual} from '@jsonjoy.com/json-pointer';
 
 export const xStrDel = (del: OpStrDel, op: Op): null | Op | Op[] => {
   if (op instanceof OpStrIns) {
+    if (!isPathEqual(del.path, op.path)) return op;
     const ins = op;
     if (ins.pos > del.pos) {
       const deleteLength = del.deleteLength();
@@ -11,6 +13,7 @@ export const xStrDel = (del: OpStrDel, op: Op): null | Op | Op[] => {
   }
 
   if (op instanceof OpStrDel) {
+    if (!isPathEqual(del.path, op.path)) return op;
     const opLen = op.deleteLength();
     const delLen = del.deleteLength();
     const overlapLen1 = del.pos + delLen - op.pos;

--- a/src/json-patch-ot/transforms/xStrIns.ts
+++ b/src/json-patch-ot/transforms/xStrIns.ts
@@ -1,11 +1,14 @@
 import {operationToOp} from '../../json-patch/codec/json';
 import {type Op, OpStrDel, OpStrIns} from '../../json-patch/op';
+import {isPathEqual} from '@jsonjoy.com/json-pointer';
 
 export const xStrIns = (ins: OpStrIns, op: Op): null | Op | Op[] => {
   if (op instanceof OpStrIns) {
+    if (!isPathEqual(ins.path, op.path)) return op;
     if (ins.pos > op.pos) return op;
     return operationToOp({...op.toJson(), pos: op.pos + ins.str.length}, {});
   } else if (op instanceof OpStrDel) {
+    if (!isPathEqual(ins.path, op.path)) return op;
     const del = op;
     if (del.pos < ins.pos) {
       const deleteLength: number = typeof del.str === 'string' ? del.str.length : del.len!;

--- a/src/json-patch-ot/transforms/xStrIns.ts
+++ b/src/json-patch-ot/transforms/xStrIns.ts
@@ -24,7 +24,7 @@ export const xStrIns = (ins: OpStrIns, op: Op): null | Op | Op[] => {
         }
       }
     }
-    if (ins.pos < del.pos) return operationToOp({...op.toJson(), pos: op.pos + ins.str.length}, {});
+    if (ins.pos <= del.pos) return operationToOp({...op.toJson(), pos: op.pos + ins.str.length}, {});
     return op;
   }
 


### PR DESCRIPTION
I was wracking my head for a more than I'd like to admit trying to figure out why I was getting corrupt patches in a collaborative text setup until I found out there were a few checks missing in the logic for str_ins and str_del.