### PR TITLE
fix(json-patch-ot): merge equal str_ins operations at same position

### DIFF
--- a/src/json-patch-ot/__tests__/scenarios.spec.ts
+++ b/src/json-patch-ot/__tests__/scenarios.spec.ts
@@ -785,6 +785,14 @@ const groups: ScenarioGroup[] = [
         user2: [{op: 'str_ins', path: '/a', pos: 2, str: '_bar_'}],
         docEnd: {a: '12_foo__bar_345'},
       },
+      {
+        // discard multiple same inserts (will typically happen in markdown task lists)
+        name: 'Inserts the same into same string at the same position.',
+        docStart: {a: '12345'},
+        user1: [{op: 'str_ins', path: '/a', pos: 2, str: '_foo_'}],
+        user2: [{op: 'str_ins', path: '/a', pos: 2, str: '_foo_'}],
+        docEnd: {a: '12_foo_345'},
+      },
     ],
   },
   {

--- a/src/json-patch-ot/transforms/xStrIns.ts
+++ b/src/json-patch-ot/transforms/xStrIns.ts
@@ -4,6 +4,7 @@ import {type Op, OpStrDel, OpStrIns} from '../../json-patch/op';
 export const xStrIns = (ins: OpStrIns, op: Op): null | Op | Op[] => {
   if (op instanceof OpStrIns) {
     if (ins.pos > op.pos) return op;
+    if (ins.pos === op.pos && ins.str === op.str) return null; // discard equal inserts
     return operationToOp({...op.toJson(), pos: op.pos + ins.str.length}, {});
   } else if (op instanceof OpStrDel) {
     const del = op;


### PR DESCRIPTION
When transforming changes in markdown this is a common scenario breaking typical edits to task lists.
It also seems more correct to merge equal inserts at the same position