### PR TITLE
perf: use Clipboard API

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "benchmark": "^2.1.4",
-    "clipboard-copy": "^4.0.1",
     "config-galore": "^1.0.0",
     "editing-traces": "https://github.com/streamich/editing-traces#145f79871a7bf54162f55d84eb6b8381db7b65b8",
     "fast-diff": "^1.3.0",

--- a/packages/json-joy/package.json
+++ b/packages/json-joy/package.json
@@ -98,7 +98,6 @@
     "@radix-ui/react-icons": "^1.3.1",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
-    "clipboard-copy": "^4.0.1",
     "collaborative-editor": "^2.9.0",
     "collaborative-input": "^1.7.0",
     "collaborative-ui": "^1.7.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,7 +39,6 @@
     "@uiw/react-color-alpha": "^2.9.6",
     "@uiw/react-color-hue": "^2.9.6",
     "@uiw/react-color-saturation": "^2.9.6",
-    "clipboard-copy": "^4.0.1",
     "code-colors-react": "^3.4.0",
     "codemirror": "^6.0.1",
     "emoji-js": "^3.9.0",

--- a/packages/ui/src/2-inline-block/CopyButton/index.tsx
+++ b/packages/ui/src/2-inline-block/CopyButton/index.tsx
@@ -5,8 +5,6 @@ import {makeIcon} from '../../icons/Iconista';
 import {BasicTooltip, type BasicTooltipProps} from '../../4-card/BasicTooltip';
 import useMountedState from 'react-use/lib/useMountedState';
 
-const copy = require('clipboard-copy'); // eslint-disable-line
-
 const CheckIcon = makeIcon({set: 'atlaskit', icon: 'check'});
 const CopyIcon = makeIcon({set: 'lucide', icon: 'copy'});
 
@@ -22,9 +20,9 @@ export const CopyButton: React.FC<CopyButtonProps> = ({onCopy, tooltip, ...rest}
   const isMounted = useMountedState();
   const [copied, setCopied] = React.useState(false);
 
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = async (e: React.MouseEvent) => {
     setCopied(true);
-    copy(onCopy());
+    await navigator.clipboard.writeText(onCopy());
     setTimeout(() => {
       if (isMounted()) setCopied(false);
     }, 2000);

--- a/packages/ui/src/markdown/inline/InlineCode/index.tsx
+++ b/packages/ui/src/markdown/inline/InlineCode/index.tsx
@@ -16,8 +16,6 @@ const getBlockquoteClass = drule({
   ...theme.font.mono.mid,
 });
 
-const copy = require('clipboard-copy'); // eslint-disable-line
-
 const {useContext} = React;
 
 interface Props {
@@ -53,8 +51,8 @@ const InlineCode: React.FC<Props> = ({idx}) => {
     return <Key>{value}</Key>;
   }
 
-  const handleClick = () => {
-    copy(value);
+  const handleClick = async () => {
+    await navigator.clipboard.writeText(value);
     toasts.add({
       title: t('Copied to clipboard!'),
       message: <blockquote className={blockquoteClass}>{value}</blockquote>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,7 +3060,6 @@ __metadata:
     "@uiw/react-color-alpha": "npm:^2.9.6"
     "@uiw/react-color-hue": "npm:^2.9.6"
     "@uiw/react-color-saturation": "npm:^2.9.6"
-    clipboard-copy: "npm:^4.0.1"
     code-colors-react: "npm:^3.4.0"
     codemirror: "npm:^6.0.1"
     emoji-js: "npm:^3.9.0"
@@ -6503,13 +6502,6 @@ __metadata:
     react-dom: "*"
     tslib: 2
   checksum: 10c0/0d65c1bd5c82a9ef1d124e8c65b80bfc1aa3403183da529113a6716b91387e5bac85faebb68337588d1fca65fc698c0f94de728d5e8da887e03d6b86d0505266
-  languageName: node
-  linkType: hard
-
-"clipboard-copy@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "clipboard-copy@npm:4.0.1"
-  checksum: 10c0/382438f78d43512df755740ebcaa6bfa3413bfaf0e7096137799acea88583b3e2ab17164348912c36216d56e69227c47c705da77c50ad8da57456cde8cad0d43
   languageName: node
   linkType: hard
 
@@ -10429,7 +10421,6 @@ __metadata:
     "@types/react": "npm:^19"
     "@types/react-dom": "npm:^19"
     benchmark: "npm:^2.1.4"
-    clipboard-copy: "npm:^4.0.1"
     config-galore: "npm:^1.0.0"
     editing-traces: "https://github.com/streamich/editing-traces#145f79871a7bf54162f55d84eb6b8381db7b65b8"
     fast-diff: "npm:^1.3.0"
@@ -10512,7 +10503,6 @@ __metadata:
     "@types/react": "npm:^19.1.12"
     "@types/react-dom": "npm:^19.1.9"
     arg: "npm:^5.0.2"
-    clipboard-copy: "npm:^4.0.1"
     collaborative-editor: "npm:^2.9.0"
     collaborative-input: "npm:^1.7.0"
     collaborative-ui: "npm:^1.7.1"
@@ -11647,7 +11637,6 @@ __metadata:
     "@uiw/react-color-alpha": "npm:^2.9.6"
     "@uiw/react-color-hue": "npm:^2.9.6"
     "@uiw/react-color-saturation": "npm:^2.9.6"
-    clipboard-copy: "npm:^4.0.1"
     code-colors-react: "npm:^3.4.0"
     codemirror: "npm:^6.0.1"
     emoji-js: "npm:^3.9.0"


### PR DESCRIPTION
Removes a dependency in favor of the widely supported [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API). This PR was made as part of the [e18e initiative](https://e18e.dev/).