### PR TITLE
feat(json-crdt): writable plain proxy `.w` for object/array-style editing

### DIFF
--- a/packages/json-joy/src/json-crdt/__demos__/writable-proxy.ts
+++ b/packages/json-joy/src/json-crdt/__demos__/writable-proxy.ts
@@ -1,0 +1,60 @@
+/* tslint:disable no-console */
+
+/**
+ * Demonstrates the writable, view-shaped proxy `.w`, which lets you edit a
+ * JSON CRDT document with ordinary object/array assignment while every
+ * mutation records a CRDT operation under the hood.
+ *
+ * Run this demo with:
+ *
+ *     npx nodemon -q -x ts-node src/json-crdt/__demos__/writable-proxy.ts
+ */
+
+import {Model, type n} from '..';
+
+const model = Model.create(void 0, 1234) as any as Model<
+  n.obj<{
+    title: n.str;
+    fps: n.con<number>;
+    clips: n.arr<n.obj<{name: n.str; start: n.con<number>}>>;
+  }>
+>;
+
+model.api.set({
+  title: 'My project',
+  fps: 30,
+  clips: [
+    {name: 'intro', start: 0},
+    {name: 'scene-1', start: 120},
+  ],
+});
+
+console.log('initial:', model.view());
+
+// Read like a plain object: scalars are values, arrays are real arrays.
+console.log('title:', model.w.title); // "My project"
+console.log('fps:', model.w.fps); // 30
+console.log('clips.length:', model.w.clips.length); // 2
+console.log(
+  'clip names:',
+  model.w.clips.map((c) => c.name),
+); // ["intro", "scene-1"]
+
+// Write like a plain object/array: each assignment records a CRDT op.
+model.w.title = 'My edited project';
+model.w.fps = 60;
+model.w.clips.push({name: 'outro', start: 240}); // real Array.push
+model.w.clips[0].name = 'opening'; // deep element field edit
+model.w.clips.at(1)!.start = 130; // .at(i) returns a live, writable proxy
+
+console.log('edited:', model.view());
+
+// `.w` writes are ordinary local changes, so they collaborate: flush the patch
+// and ship it to another replica, which converges.
+const patch = model.api.flush();
+const replica = Model.create(void 0, 5678) as any as typeof model;
+replica.api.flush();
+replica.applyPatch(patch);
+
+console.log('replica:', replica.view());
+console.log('converged:', JSON.stringify(replica.view()) === JSON.stringify(model.view()));

--- a/packages/json-joy/src/json-crdt/model/Model.ts
+++ b/packages/json-joy/src/json-crdt/model/Model.ts
@@ -270,6 +270,26 @@ export class Model<N extends JsonNode = JsonNode<any>> implements Printable {
   }
 
   /**
+   * Experimental *writable* plain proxy of the document — the read/write
+   * sibling of {@link view} (a detached read-only snapshot) and {@link s} (the
+   * node proxy that exposes every handle for manual control). Reading mirrors
+   * the plain-JSON view and assignment records CRDT operations, so the document
+   * can be edited like an ordinary JavaScript object/array:
+   *
+   * ```ts
+   * model.w.title = 'Hello';
+   * model.w.tracks.push(track);          // arrays are real arrays
+   * model.w.tracks[0].name = 'opening';  // deep element edits
+   * ```
+   *
+   * For node handles (in-place string ops, etc.) use `.s`. Automatically
+   * resolves nested "val" nodes. See the `NodeApi.w` accessor.
+   */
+  public get w() {
+    return this.api.w;
+  }
+
+  /**
    * Experimental strictly typed node retrieval API using proxy objects.
    * Automatically resolves nested "val" nodes.
    */

--- a/packages/json-joy/src/json-crdt/model/api/__tests__/NodeApi.wproxy.spec.ts
+++ b/packages/json-joy/src/json-crdt/model/api/__tests__/NodeApi.wproxy.spec.ts
@@ -1,0 +1,279 @@
+import {Model} from '../../Model';
+import {s} from '../../../../json-crdt-patch';
+
+const setup = () =>
+  Model.create(
+    s.obj({
+      title: s.str('Hello'),
+      count: s.con(1234),
+      flag: s.con(true),
+      obj: s.obj({
+        nested: s.obj({
+          address: s.obj({
+            street: s.str('1st Ave'),
+            city: s.str('New York'),
+          }),
+        }),
+      }),
+      val: s.val(s.con('register')),
+      vec: s.vec(s.con('a'), s.con('b'), s.con(true)),
+      arr: s.arr([s.con('x'), s.con('y'), s.con('z')]),
+    }),
+  );
+
+describe('.w reads', () => {
+  test('reads leaf scalars as raw values', () => {
+    const model = setup();
+    expect(model.w.title).toBe('Hello');
+    expect(model.w.count).toBe(1234);
+    expect(model.w.flag).toBe(true);
+  });
+
+  test('reads nested object properties', () => {
+    const model = setup();
+    expect(model.w.obj.nested.address.city).toBe('New York');
+    expect(model.w.obj.nested.address.street).toBe('1st Ave');
+  });
+
+  test('resolves "val" registers transparently', () => {
+    const model = setup();
+    expect(model.w.val).toBe('register');
+  });
+
+  test('reads array elements by index and exposes length', () => {
+    const model = setup();
+    expect(model.w.arr[0]).toBe('x');
+    expect(model.w.arr[2]).toBe('z');
+    expect(model.w.arr.length).toBe(3);
+  });
+
+  test('reads vector elements by index', () => {
+    const model = setup();
+    expect(model.w.vec[0]).toBe('a');
+    expect(model.w.vec[2]).toBe(true);
+  });
+
+  test('missing object keys read back as undefined (not throwing)', () => {
+    const model = setup();
+    expect((model.w as any).doesNotExist).toBe(undefined);
+  });
+
+  test('reads as a plain object deep-equal to view()', () => {
+    const model = setup();
+    expect(JSON.parse(JSON.stringify(model.w))).toEqual(model.view());
+  });
+
+  test('node handles remain available through `.s` (manual control)', () => {
+    const model = setup();
+    expect(typeof model.s.arr.$.push).toBe('function');
+    expect(model.s.arr.$.length()).toBe(3);
+  });
+
+  test('supports has / Object.keys / spread on objects', () => {
+    const model = setup();
+    expect('title' in model.w).toBe(true);
+    expect('nope' in model.w).toBe(false);
+    expect(Object.keys(model.w).sort()).toEqual(['arr', 'count', 'flag', 'obj', 'title', 'val', 'vec']);
+    expect({...model.w.obj.nested.address}).toEqual({street: '1st Ave', city: 'New York'});
+  });
+});
+
+describe('.w object writes', () => {
+  test('assigning an existing key records an op and updates the view', () => {
+    const model = setup();
+    model.w.title = 'World';
+    expect(model.w.title).toBe('World');
+    expect(model.view().title).toBe('World');
+  });
+
+  test('assigning a new key adds it', () => {
+    const model = setup();
+    (model.w as any).extra = 42;
+    expect((model.view() as any).extra).toBe(42);
+  });
+
+  test('deleting a key removes it', () => {
+    const model = setup();
+    delete (model.w as any).title;
+    expect((model.view() as any).title).toBe(undefined);
+    expect('title' in model.w).toBe(false);
+  });
+
+  test('deep nested assignment works through the proxy chain', () => {
+    const model = setup();
+    model.w.obj.nested.address.city = 'Los Angeles';
+    expect(model.w.obj.nested.address.city).toBe('Los Angeles');
+    expect(model.view().obj.nested.address.city).toBe('Los Angeles');
+    // sibling untouched
+    expect(model.view().obj.nested.address.street).toBe('1st Ave');
+  });
+
+  test('assigning a whole object value builds a subtree', () => {
+    const model = setup();
+    (model.w as any).meta = {a: 1, b: {c: 2}};
+    expect((model.view() as any).meta).toEqual({a: 1, b: {c: 2}});
+  });
+});
+
+describe('.w array writes', () => {
+  test('assigning to an existing index overwrites the element', () => {
+    const model = setup();
+    model.w.arr[1] = 'Y2';
+    expect(model.view().arr).toEqual(['x', 'Y2', 'z']);
+  });
+
+  test('assigning to index === length appends', () => {
+    const model = setup();
+    model.w.arr[3] = 'w';
+    expect(model.view().arr).toEqual(['x', 'y', 'z', 'w']);
+  });
+
+  test('assigning past the end throws OUT_OF_BOUNDS', () => {
+    const model = setup();
+    expect(() => {
+      model.w.arr[10] = 'too far';
+    }).toThrow('OUT_OF_BOUNDS');
+  });
+
+  test('deleting an index removes the element', () => {
+    const model = setup();
+    delete model.w.arr[1];
+    expect(model.view().arr).toEqual(['x', 'z']);
+  });
+
+  test('push / pop / shift / unshift behave like a real array', () => {
+    const model = setup();
+    expect(model.w.arr.push('w')).toBe(4);
+    expect(model.view().arr).toEqual(['x', 'y', 'z', 'w']);
+    expect(model.w.arr.pop()).toBe('w');
+    expect(model.view().arr).toEqual(['x', 'y', 'z']);
+    expect(model.w.arr.shift()).toBe('x');
+    expect(model.view().arr).toEqual(['y', 'z']);
+    expect(model.w.arr.unshift('a', 'b')).toBe(4);
+    expect(model.view().arr).toEqual(['a', 'b', 'y', 'z']);
+  });
+
+  test('splice inserts and removes', () => {
+    const model = setup();
+    const removed = model.w.arr.splice(1, 1, 'Y', 'Y2');
+    expect(removed).toEqual(['y']);
+    expect(model.view().arr).toEqual(['x', 'Y', 'Y2', 'z']);
+  });
+
+  test('sort / reverse reconcile via merge', () => {
+    const model = setup();
+    model.w.arr.reverse();
+    expect(model.view().arr).toEqual(['z', 'y', 'x']);
+    model.w.arr.sort();
+    expect(model.view().arr).toEqual(['x', 'y', 'z']);
+  });
+
+  test('arr.length = n truncates', () => {
+    const model = setup();
+    model.w.arr.length = 1;
+    expect(model.view().arr).toEqual(['x']);
+  });
+
+  test('mixing .w array methods with .s node handles', () => {
+    const model = setup();
+    model.s.arr.$.ins(0, ['start']); // manual insert via the node API
+    model.w.arr.push('end'); // ergonomic append via the writable proxy
+    expect(model.view().arr).toEqual(['start', 'x', 'y', 'z', 'end']);
+  });
+});
+
+describe('.w array reads behave like a plain array', () => {
+  test('iteration, spread, map, indexOf, includes', () => {
+    const model = setup();
+    expect([...model.w.arr]).toEqual(['x', 'y', 'z']);
+    expect(model.w.arr.map((v) => v.toUpperCase())).toEqual(['X', 'Y', 'Z']);
+    expect(model.w.arr.indexOf('y')).toBe(1);
+    expect(model.w.arr.includes('z')).toBe(true);
+    let joined = '';
+    for (const v of model.w.arr) joined += v;
+    expect(joined).toBe('xyz');
+  });
+});
+
+describe('.w deep element mutation (arrays of objects)', () => {
+  const objArr = () =>
+    Model.create(
+      s.obj({
+        items: s.arr([s.obj({name: s.str('a'), n: s.con(1)}), s.obj({name: s.str('b'), n: s.con(2)})]),
+      }),
+    );
+
+  test('arr[i].field = value mutates the element in place', () => {
+    const model = objArr();
+    model.w.items[0].name = 'A';
+    model.w.items[0].n = 11;
+    expect(model.view().items[0]).toEqual({name: 'A', n: 11});
+    expect(model.view().items[1]).toEqual({name: 'b', n: 2});
+  });
+
+  test('arr.at(i).field = value mutates the element (deep proxy, not a snapshot)', () => {
+    const model = objArr();
+    model.w.items.at(1)!.name = 'B';
+    expect(model.view().items[1].name).toBe('B');
+  });
+
+  test('map yields live element proxies that can be mutated', () => {
+    const model = objArr();
+    model.w.items.map((item) => {
+      item.name = item.name.toUpperCase();
+    });
+    expect(model.view().items.map((i) => i.name)).toEqual(['A', 'B']);
+  });
+
+  test('for...of yields live element proxies', () => {
+    const model = objArr();
+    for (const item of model.w.items) item.n = (item.n as number) * 10;
+    expect(model.view().items.map((i) => i.n)).toEqual([10, 20]);
+  });
+});
+
+describe('.w vector writes', () => {
+  test('assigning to an index overwrites the element', () => {
+    const model = setup();
+    model.w.vec[1] = 'B2';
+    expect(model.view().vec).toEqual(['a', 'B2', true]);
+  });
+
+  test('out-of-range vector index assignment is rejected', () => {
+    const model = setup();
+    expect(() => {
+      // vectors are fixed-length; index 9 does not exist
+      (model.w.vec as any)[9] = 'nope';
+    }).toThrow();
+  });
+});
+
+describe('.w on sub-nodes', () => {
+  test('can take a writable proxy of a sub-node and mutate it', () => {
+    const model = setup();
+    const address = model.api.obj(['obj', 'nested', 'address']).w;
+    address.city = 'Boston';
+    expect(model.view().obj.nested.address.city).toBe('Boston');
+  });
+});
+
+describe('.w records collaborative operations (convergence)', () => {
+  test('writes emit a patch that converges a forked replica', () => {
+    const local = setup();
+    local.api.flush();
+    const remote = local.fork();
+    // Mutate the local replica purely through the writable proxy.
+    local.w.title = 'Edited';
+    local.w.obj.nested.address.city = 'Seattle';
+    local.w.arr[0] = 'X';
+    local.w.arr.push('new');
+    const patch = local.api.flush();
+    expect(patch.ops.length).toBeGreaterThan(0);
+    // Ship the patch to the remote replica.
+    remote.applyPatch(patch);
+    expect(remote.view()).toEqual(local.view());
+    expect(remote.view().title).toBe('Edited');
+    expect(remote.view().obj.nested.address.city).toBe('Seattle');
+    expect(remote.view().arr).toEqual(['X', 'y', 'z', 'new']);
+  });
+});

--- a/packages/json-joy/src/json-crdt/model/api/nodes.ts
+++ b/packages/json-joy/src/json-crdt/model/api/nodes.ts
@@ -346,6 +346,21 @@ export class NodeApi<N extends JsonNode = JsonNode> implements Printable {
     return {$: this} as unknown as types.ProxyNode<N>;
   }
 
+  /**
+   * Returns a *writable* plain proxy of this node — the read/write sibling of
+   * `view()` (read-only snapshot) and `.s` (node proxy with all handles).
+   * Reading container properties returns nested writable proxies, reading leaf
+   * nodes (`con`/`str`/`bin`) returns their raw value, and assignment records
+   * CRDT operations. It is shaped like the plain data; for node handles use
+   * `.s`. See {@link types.WProxyNode} for details and caveats.
+   *
+   * The base implementation covers leaf nodes by returning their view; `obj`,
+   * `arr`, `vec` and `val` nodes override it with the appropriate proxy.
+   */
+  public get w(): types.WProxyNode<N> {
+    return this.view() as types.WProxyNode<N>;
+  }
+
   public get $(): JsonNodeToProxyPathNode<N> {
     return proxy$((path) => {
       try {
@@ -534,6 +549,16 @@ export class ValApi<N extends ValNode<any> = ValNode<any>> extends NodeApi<N> {
     };
     return <any>proxy;
   }
+
+  /**
+   * Writable proxy of this `val` node. `val` registers are transparent in the
+   * view, so `.w` resolves through to the inner value's writable proxy. To
+   * overwrite the register itself use `.set(value)` (or assign through the
+   * parent container).
+   */
+  public get w(): types.WProxyNode<N> {
+    return (this.api.wrap(this.node.node()) as any).w;
+  }
 }
 
 type UnVecNode<N> = N extends VecNode<infer T> ? T : never;
@@ -604,6 +629,42 @@ export class VecApi<N extends VecNode<any> = VecNode<any>> extends NodeApi<N> {
       },
     );
     return proxy as types.ProxyNodeVec<N>;
+  }
+
+  /**
+   * Writable, view-shaped proxy of this `vec` node. Elements are addressed by
+   * index; assigning to an index overwrites that element. The vector length is
+   * fixed, so out-of-range indices are rejected.
+   */
+  public get w(): types.WProxyNode<N> {
+    return new Proxy([] as unknown[], {
+      get: (target, prop) => {
+        if (prop === '$') return this;
+        if (prop === 'length') return this.length();
+        if (typeof prop === 'string') {
+          const index = Number(prop);
+          if (!Number.isNaN(index)) {
+            const child = this.node.get(index);
+            return child ? (this.api.wrap(child as JsonNode) as any).w : undefined;
+          }
+        }
+        // Delegate other reads (iteration, map, JSON serialization, …) to a
+        // materialized array of element proxies.
+        const length = this.length();
+        const elements = new Array(length);
+        for (let i = 0; i < length; i++) elements[i] = (this.api.wrap(this.node.get(i) as JsonNode) as any).w;
+        const value = (elements as any)[prop];
+        return typeof value === 'function' ? value.bind(elements) : value;
+      },
+      set: (target, prop, value) => {
+        if (prop === '$' || prop === 'length' || typeof prop === 'symbol') return false;
+        const index = Number(prop);
+        if (Number.isNaN(index) || index < 0 || index >= this.length()) return false;
+        this.set([[index, value as unknown]]);
+        return true;
+      },
+      deleteProperty: () => false, // vectors are fixed-length
+    }) as types.WProxyNode<N>;
   }
 }
 
@@ -699,6 +760,50 @@ export class ObjApi<N extends ObjNode<any> = ObjNode<any>> extends NodeApi<N> {
       },
     );
     return proxy as types.ProxyNodeObj<N>;
+  }
+
+  /**
+   * Writable, view-shaped proxy of this `obj` node. Reading a key returns the
+   * nested writable proxy (containers) or the raw value (leaves); assigning a
+   * key records an `obj` set operation; deleting a key records a delete.
+   * Missing keys read back as `undefined` (rather than throwing, unlike `.s`),
+   * matching plain-object semantics. Use `.s` for node handles.
+   */
+  public get w(): types.WProxyNode<N> {
+    return new Proxy(
+      {},
+      {
+        get: (target, prop) => {
+          if (prop === '$') return this;
+          if (typeof prop === 'symbol') return (target as any)[prop];
+          const child = this.node.get(String(prop));
+          if (!child) return undefined;
+          return (this.api.wrap(child) as any).w;
+        },
+        set: (target, prop, value) => {
+          if (prop === '$' || typeof prop === 'symbol') return false;
+          this.set({[String(prop)]: value} as Partial<JsonNodeView<N>>);
+          return true;
+        },
+        deleteProperty: (target, prop) => {
+          if (typeof prop === 'symbol') return false;
+          this.del([String(prop)]);
+          return true;
+        },
+        has: (target, prop) => {
+          if (prop === '$') return true;
+          if (typeof prop === 'symbol') return false;
+          // Mirror the view: keys deleted via a `con(undefined)` tombstone are
+          // absent from the view and must read as absent here too.
+          return String(prop) in (this.view() as object);
+        },
+        ownKeys: () => Object.keys(this.view() as object),
+        getOwnPropertyDescriptor: (target, prop) => {
+          if (typeof prop === 'symbol' || !(String(prop) in (this.view() as object))) return undefined;
+          return {enumerable: true, configurable: true};
+        },
+      },
+    ) as types.WProxyNode<N>;
   }
 }
 
@@ -962,6 +1067,118 @@ export class ArrApi<N extends ArrNode<any> = ArrNode<any>> extends NodeApi<N> {
       },
     );
     return proxy as types.ProxyNodeArr<N>;
+  }
+
+  /**
+   * Writable proxy of this `arr` node that behaves like an ordinary JavaScript
+   * array. Indexing, `length`, iteration and the standard read methods all
+   * work; the mutating methods record CRDT operations:
+   *
+   * - `push`/`pop`/`shift`/`unshift`/`splice` map directly to insert/delete ops
+   * - `sort`/`reverse`/`fill` compute the resulting array and reconcile it via
+   *   `merge()` (minimal ops)
+   * - `arr[i] = value` overwrites, `arr[length] = value` appends, `delete arr[i]`
+   *   removes, `arr.length = n` truncates
+   *
+   * Indexing (`arr[i]`) and every element-returning method (`at`, `map`,
+   * `find`, iteration, spread, …) return that element's writable proxy, so
+   * nested containers are deeply navigable and mutable — e.g.
+   * `arr.at(0).field = x` records an op. For leaf elements (`con`/`str`) that
+   * proxy is just the raw value, so primitive arrays behave exactly like plain
+   * arrays. Use `.s` for the imperative node API.
+   */
+  public get w(): types.WProxyNode<N> {
+    type El = JsonNodeView<N>[number];
+    const mutators: Record<string, (...args: any[]) => unknown> = {
+      push: (...items: El[]) => {
+        if (items.length) this.push(...items);
+        return this.length();
+      },
+      pop: () => {
+        const len = this.length();
+        if (!len) return undefined;
+        const value = (this.view() as unknown[])[len - 1];
+        this.del(len - 1, 1);
+        return value;
+      },
+      shift: () => {
+        if (!this.length()) return undefined;
+        const value = (this.view() as unknown[])[0];
+        this.del(0, 1);
+        return value;
+      },
+      unshift: (...items: El[]) => {
+        if (items.length) this.ins(0, items);
+        return this.length();
+      },
+      splice: (start: number, deleteCount?: number, ...items: El[]) => {
+        const len = this.length();
+        const from = start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
+        const count = deleteCount === undefined ? len - from : Math.max(0, Math.min(deleteCount, len - from));
+        const removed = (this.view() as unknown[]).slice(from, from + count);
+        if (count) this.del(from, count);
+        if (items.length) this.ins(from, items);
+        return removed;
+      },
+      reverse: () => {
+        this.merge((this.view() as unknown[]).slice().reverse());
+        return this.w;
+      },
+      sort: (compareFn?: (a: unknown, b: unknown) => number) => {
+        this.merge((this.view() as unknown[]).slice().sort(compareFn));
+        return this.w;
+      },
+      fill: (value: El, start?: number, end?: number) => {
+        this.merge((this.view() as unknown[]).slice().fill(value, start, end));
+        return this.w;
+      },
+    };
+    return new Proxy([] as unknown[], {
+      get: (target, prop) => {
+        if (prop === '$') return this;
+        if (prop === 'length') return this.length();
+        if (typeof prop === 'string') {
+          if (prop in mutators) return mutators[prop];
+          const index = Number(prop);
+          if (!Number.isNaN(index)) {
+            const child = this.node.getNode(index);
+            return child ? (this.api.wrap(child) as any).w : undefined;
+          }
+        }
+        // Delegate every other read (iteration, map, at, find, …) to a
+        // materialized array of element *proxies*, so element access stays live
+        // and deeply mutable and the proxy otherwise behaves like a plain array.
+        const length = this.length();
+        const elements = new Array(length);
+        for (let i = 0; i < length; i++) elements[i] = (this.api.wrap(this.node.getNode(i)!) as any).w;
+        const value = (elements as any)[prop];
+        return typeof value === 'function' ? value.bind(elements) : value;
+      },
+      set: (target, prop, value) => {
+        if (prop === '$' || typeof prop === 'symbol') return false;
+        if (prop === 'length') {
+          const next = Number(value);
+          const len = this.length();
+          if (Number.isNaN(next) || next < 0) return false;
+          if (next < len) this.del(next, len - next);
+          return true;
+        }
+        const index = Number(prop);
+        if (Number.isNaN(index) || index < 0) return false;
+        const len = this.length();
+        if (index < len) this.upd(index, value as El);
+        else if (index === len) this.ins(index, [value as El]);
+        else throw new Error('OUT_OF_BOUNDS');
+        return true;
+      },
+      deleteProperty: (target, prop) => {
+        if (typeof prop === 'symbol') return false;
+        const index = Number(prop);
+        if (Number.isNaN(index) || index < 0 || index >= this.length()) return false;
+        this.del(index, 1);
+        return true;
+      },
+    }) as types.WProxyNode<N>;
   }
 }
 

--- a/packages/json-joy/src/json-crdt/model/api/proxy.ts
+++ b/packages/json-joy/src/json-crdt/model/api/proxy.ts
@@ -9,6 +9,80 @@ export interface ProxyNode<N extends nodes.JsonNode = nodes.JsonNode> {
   $: JsonNodeApi<N>;
 }
 
+/**
+ * `WProxyNode` is the *writable* counterpart of `view()`: it mirrors the
+ * plain-JSON view of the document, but reading and writing it records CRDT
+ * operations. It is shaped exactly like the data — there are no node handles in
+ * the type, so it edits like a plain object/array:
+ *
+ * ```ts
+ * model.w.title = 'Hello';              // ObjApi.set({title: 'Hello'})
+ * model.w.tracks.push(track);           // ArrApi.push(track)
+ * model.w.tracks[0].name = 'opening';   // deep field edit on element 0
+ * model.w.config = {fps: 30};           // whole-object assignment
+ * ```
+ *
+ * This is the read/write sibling of the two existing proxies: `view()` is a
+ * detached read-only snapshot, `.s` is the node proxy that exposes every
+ * handle (`$`, `ins`/`del`, …) for manual control, and `.w` is the ergonomic
+ * plain read/write layer. When you need a node handle from inside a `.w` edit,
+ * reach for `.s` (e.g. `model.s.title.$.ins(5, '!')` for in-place string ops).
+ *
+ * Notes:
+ * - `val` nodes are transparent — `.w` resolves through them to the inner value.
+ * - Leaf nodes (`con`/`str`/`bin`) read back as their raw value; `str` widens to
+ *   `string` and `bin` to `Uint8Array` so reassignment type-checks.
+ * - Deleting a (non-optional) declared key still needs the usual TS cast, since
+ *   `delete` is only allowed on optional properties.
+ */
+// prettier-ignore
+export type WProxyNode<N> =
+  N extends nodes.ConNode<infer V>
+    ? V
+    : N extends nodes.RootNode<infer M>
+      ? WProxyNode<M>
+      : N extends nodes.ValNode<infer T>
+        ? WProxyNode<T>
+        : N extends nodes.StrNode
+          ? string
+          : N extends nodes.BinNode
+            ? Uint8Array
+            : N extends nodes.ArrNode<infer E>
+              ? WProxyNodeArr<E>
+              : N extends nodes.ObjNode<infer M>
+                ? WProxyNodeObj<M>
+                : N extends nodes.VecNode<any>
+                  ? WProxyNodeVec<N>
+                  : unknown;
+
+export type WProxyNodeObj<M extends Record<string, nodes.JsonNode>> = {
+  -readonly [K in keyof M]: WProxyNode<M[K]>;
+};
+
+/**
+ * `arr` nodes read and mutate like an ordinary array: indexing, `length`,
+ * iteration, and the standard methods (`map`/`filter`/`forEach`/…) all work,
+ * and the mutating methods (`push`/`pop`/`shift`/`unshift`/`splice`/`sort`/
+ * `reverse`/`fill`) record CRDT operations. Indexing and the element-returning
+ * methods (`arr[i]`, `at`, `find`, iteration, …) yield each element's writable
+ * proxy, so nested containers stay deeply navigable and mutable.
+ */
+export type WProxyNodeArr<E extends nodes.JsonNode> = WProxyNode<E>[];
+
+export type WProxyNodeVec<N extends nodes.VecNode<any>> = {
+  -readonly [K in keyof nodes.JsonNodeView<N>]: JsonNodeToWProxyElement<N, K>;
+};
+
+// Helper: element type of a `vec` tuple at key `K`, as a writable proxy node.
+type JsonNodeToWProxyElement<N extends nodes.VecNode<any>, K> =
+  N extends nodes.VecNode<infer T>
+    ? K extends keyof T
+      ? T[K] extends nodes.JsonNode
+        ? WProxyNode<T[K]>
+        : unknown
+      : unknown
+    : unknown;
+
 export type ProxyNodeCon<N extends nodes.ConNode<any>> = ProxyNode<N>;
 export type ProxyNodeVal<N extends nodes.ValNode<any>> = ProxyNode<N> & {
   _: JsonNodeToProxyNode<ReturnType<N['child']>>;


### PR DESCRIPTION
## What

Adds **`.w`**, a writable plain proxy of the document — the read/write sibling of the existing accessors:

- **`view()`** — detached, read-only snapshot
- **`.s`** — node proxy exposing every handle (`$`, `ins`/`del`, …) for manual control
- **`.w`** — ergonomic layer that edits like a plain object/array while recording CRDT ops

```ts
model.w.title = 'Hello';             // obj set
model.w.tracks.push(track);          // arrays are real arrays
model.w.tracks[0].name = 'opening';  // deep element field edit
model.w.tracks.at(1).start = 130;    // element access → live proxy
model.w.config = {fps: 30};          // whole-object assignment
```

## Design

- **`.w` is typed as the plain view shape** — no node handles in the type, so assignment of plain values (including `push(obj)` and whole-object assignment) type-checks. When you need a handle inside a `.w` edit, reach for `.s` (e.g. `model.s.title.$.ins(5, '!')` for in-place string ops). This keeps a clean split: `.s` = manual/full control, `.w` = plain editing.
- **Arrays behave like real arrays.** `push`/`pop`/`shift`/`unshift`/`splice` map to insert/delete ops; `sort`/`reverse`/`fill` reconcile via `merge()`. Indexing and element-returning methods (`arr[i]`, `at`, `find`, iteration, `map`) yield **live element proxies**, so nested containers are deeply navigable and mutable.
- **`val` nodes are transparent**; leaf nodes read as their value (`str` widens to `string`, `bin` to `Uint8Array` so reassignment type-checks).
- **Purely additive** — reads and the existing `.s` / `.$` proxies are unchanged.

The complementary "reconcile a whole value → minimal ops" path already exists via `NodeApi.diff()` / `NodeApi.merge()`; `.w` is for direct property/element edits.

### Known TS edge

`delete model.w.someDeclaredKey` needs a cast, because TypeScript only allows `delete` on optional properties. (Index/`con` deletes and `delete arr[i]` are fine.)

## Tests & demo

- `NodeApi.wproxy.spec.ts` — 32 cases: leaf/nested/array/vec reads, val transparency, object set/add/delete, deep assignment, real-array methods (push/pop/shift/unshift/splice/sort/reverse/length), deep element mutation via `[i]` / `.at(i)` / `map` / `for…of`, `JSON.stringify` round-trip, `.s`-handle interop, and a **fork → edit via `.w` → flush → applyPatch → converge** test.
- `__demos__/writable-proxy.ts` — runnable demo.
- Locally: `yarn build` + `yarn typecheck` green; `biome format`/`lint` clean on changed files; full json-crdt + extensions suite (6597 tests) passes with no regressions.

Naming (`.w`) and the view-shaped-vs-node-shaped split are easy to adjust to your preference for the proxy API.