### PR TITLE
fix(json-crdt): guard ObjNode.children against missing nodes

### DIFF
--- a/packages/json-joy/src/json-crdt/nodes/obj/ObjNode.ts
+++ b/packages/json-joy/src/json-crdt/nodes/obj/ObjNode.ts
@@ -87,7 +87,10 @@ export class ObjNode<Value extends Record<string, JsonNode> = Record<string, Jso
   /** @ignore */
   public children(callback: (node: JsonNode) => void) {
     const index = this.doc.index;
-    this.keys.forEach((id, key) => callback(index.get(id)!));
+    this.keys.forEach((id) => {
+      const node = index.get(id);
+      if (node) callback(node);
+    });
   }
 
   /** @ignore */


### PR DESCRIPTION
## Problem

`ObjNode.children()` passes the result of `index.get(id)` straight to the callback with a non-null assertion:

```ts
public children(callback: (node: JsonNode) => void) {
  const index = this.doc.index;
  this.keys.forEach((id, key) => callback(index.get(id)!));
}
```

`index.get(id)` can legitimately return `undefined` when a key references a node id that is not present in the model index (e.g. a dangling reference encountered while applying a patch). The `!` assertion hides this, so `undefined` reaches the callback.

The most visible symptom is a crash in `Model._gcTree` (formerly `deleteNodeTree`), which reads `value.sid` on its argument before the `index.get` existence check:

```ts
_gcTree(value: ITimestampStruct) {
  const isSystemNode = value.sid === 0;  // TypeError: Cannot read properties of undefined (reading 'sid')
  ...
  node.children((child) => this._gcTree(child.id));
}
```

When an `ObjNode` has a child key pointing at a missing node, `children()` invokes the callback with `undefined`, and `_gcTree(undefined)` throws `Cannot read properties of undefined (reading 'sid')`, aborting the whole patch/GC pass.

## Fix

Guard against the missing node before invoking the callback — exactly what `ArrNode.children()` and `VecNode.children()` already do:

```ts
public children(callback: (node: JsonNode) => void) {
  const index = this.doc.index;
  this.keys.forEach((id) => {
    const node = index.get(id);
    if (node) callback(node);
  });
}
```

This makes `ObjNode` consistent with the other collection nodes:

- `ArrNode.children`: `const node = index.get(data[i]); if (node) callback(node);`
- `VecNode.children`: `const node = index.get(id); if (node) callback(node);`

Only `ObjNode` was missing the guard (and additionally used an unsound `!`). No behavior change for well-formed models; it only prevents a hard crash when a dangling reference is present.
