### PR TITLE
fix(collaborative-prosemirror): never throw restoring the selection on a remote update

### DIFF
--- a/packages/collaborative-prosemirror/src/ProseMirrorFacade.ts
+++ b/packages/collaborative-prosemirror/src/ProseMirrorFacade.ts
@@ -217,7 +217,12 @@ export class ProseMirrorFacade implements RichtextEditorFacade {
     if (!tr.docChanged) return;
     const newAnchor = tr.mapping.map(selection.anchor);
     const newHead = tr.mapping.map(selection.head);
-    tr.setSelection(TextSelection.create(tr.doc, newAnchor, newHead));
+    // `TextSelection.between` never throws: when a full-document replace maps the
+    // old selection outside inline content, `TextSelection.create` throws — and,
+    // because `set()` runs inside `PeritextBinding.bind()`'s initial
+    // `syncFromModel()`, that exception aborts the whole binding: the editor stays
+    // permanently unwired and local edits are silently lost.
+    tr.setSelection(TextSelection.between(tr.doc.resolve(newAnchor), tr.doc.resolve(newHead)));
     const meta: SyncPluginTransactionMeta = {orig: TransactionOrigin.REMOTE};
     tr.setMeta(SYNC_PLUGIN_KEY, meta);
     tr.setMeta('addToHistory', false);
@@ -250,7 +255,10 @@ export class ProseMirrorFacade implements RichtextEditorFacade {
     const headPoint = startIsAnchor ? range.end : range.start;
     const anchor = pointToPmPos(rootBlock, anchorPoint, doc);
     const head = pointToPmPos(rootBlock, headPoint, doc);
-    const newSelection = TextSelection.create(doc, anchor, head);
+    // Same hazard as `set()` above: a CRDT-space selection can resolve to a
+    // position without inline content (e.g. around block boundaries mid-sync);
+    // `between` clamps to the nearest valid text selection instead of throwing.
+    const newSelection = TextSelection.between(doc.resolve(anchor), doc.resolve(head));
     const tr = state.tr.setSelection(newSelection);
     const meta: SyncPluginTransactionMeta = {orig: TransactionOrigin.REMOTE};
     tr.setMeta(SYNC_PLUGIN_KEY, meta);

--- a/packages/collaborative-prosemirror/src/__tests__/ProseMirrorFacade.selection-restore.spec.ts
+++ b/packages/collaborative-prosemirror/src/__tests__/ProseMirrorFacade.selection-restore.spec.ts
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+
+import {TextSelection} from 'prosemirror-state';
+import type {Node} from 'prosemirror-model';
+import {doc, p} from 'prosemirror-test-builder';
+import {ModelWithExt as Model, ext} from 'json-joy/lib/json-crdt-extensions';
+import {FromPm} from '../sync/FromPm';
+import {setup} from './setup';
+import {onlyNode24AndHigher} from './test-helpers';
+
+/** Build a Peritext `txt.blocks` fragment equivalent to the given PM doc. */
+const fragmentOf = (pmDoc: Node) => {
+  const model = Model.create(ext.peritext.new(''));
+  const api = model.s.toExt();
+  api.txt.editor.import(0, FromPm.convert(pmDoc));
+  api.txt.refresh();
+  return api.txt.blocks;
+};
+
+onlyNode24AndHigher('ProseMirrorFacade selection restore on remote set()', () => {
+  test('set() must not throw when the mapped selection lands outside inline content', () => {
+    // Local doc has three paragraphs and the user's caret sits in the LAST one.
+    const pmDoc = doc(p('aaa'), p('bbb'), p('ccc')) as Node;
+    using testbed = setup(pmDoc);
+    const {facade, view} = testbed;
+
+    // Caret inside "ccc" (last textblock).
+    const endPos = view.state.doc.content.size - 2;
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, endPos)));
+
+    // A remote update replaces the document with a SHORTER one — the trailing
+    // blocks (including the one holding the caret) disappear. The old caret
+    // position maps to the end of the new doc, which is a doc-level position
+    // with no inline content; `TextSelection.create` throws
+    // "TextSelection endpoint not pointing into a node with inline content".
+    // Because `set()` also runs inside `PeritextBinding.bind()`'s initial
+    // `syncFromModel()`, that throw aborts the whole binding: the editor stays
+    // permanently unwired and local edits are silently lost.
+    expect(() => facade.set(fragmentOf(doc(p('aaa')) as Node))).not.toThrow();
+
+    // The remote content landed…
+    expect(view.state.doc.textContent).toBe('aaa');
+    // …and the restored selection is a valid position inside inline content.
+    const sel = view.state.selection;
+    expect(sel.$head.parent.inlineContent).toBe(true);
+  });
+
+  test('set() keeps an in-range mapped selection exactly where it was', () => {
+    const pmDoc = doc(p('Hello'), p('World')) as Node;
+    using testbed = setup(pmDoc);
+    const {facade, view} = testbed;
+
+    // Caret after "He" in the first paragraph — untouched by the remote change.
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 3)));
+
+    // Remote edit only changes the SECOND paragraph.
+    facade.set(fragmentOf(doc(p('Hello'), p('Peers')) as Node));
+
+    expect(view.state.doc.textContent).toBe('HelloPeers');
+    expect(view.state.selection.head).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem

`ProseMirrorFacade.set()` maps the previous selection through the applied transaction and reinstates it with `TextSelection.create()`:

```ts
const newAnchor = tr.mapping.map(selection.anchor);
const newHead = tr.mapping.map(selection.head);
tr.setSelection(TextSelection.create(tr.doc, newAnchor, newHead));
```

When a remote update changes the document such that the mapped position no longer points into inline content — e.g. it **removes the trailing blocks that held the local caret** — `TextSelection.create()` throws:

```
TextSelection endpoint not pointing into a node with inline content (doc)
```

The consequence is worse than a caret glitch: `set()` also runs inside `PeritextBinding.bind()`'s initial `syncFromModel()`, so the exception **aborts the entire binding**. The editor stays permanently unwired, and every subsequent local edit is applied to ProseMirror only and silently lost — nothing throws afterwards, which makes it very hard to diagnose.

We hit this in production in a collaborative screenplay editor built on these packages: a client resuming a session (server snapshot replacing the body while the caret sat in later content) lost all subsequent typing on reload.

## Fix

Use `TextSelection.between()`, ProseMirror's non-throwing constructor, which clamps to the nearest valid text selection. The same hazard exists in `setSelection()` (a CRDT-space selection can resolve around block boundaries mid-sync) — guarded identically.

## Tests

New spec `ProseMirrorFacade.selection-restore.spec.ts`:
- reproduces the exact failure (caret in a trailing paragraph + a remote `set()` that removes it) — **fails with the quoted error before this change**, passes after;
- pins that in-range mapped selections are still restored exactly (no behavior change for the normal case).

All 13 existing `collaborative-prosemirror` suites pass unchanged (719 tests).
