### PR TITLE
fix: handle value-based CRDT string deletion

### DIFF
--- a/packages/json-joy/src/json-crdt/json-patch/JsonPatch.ts
+++ b/packages/json-joy/src/json-crdt/json-patch/JsonPatch.ts
@@ -46,7 +46,7 @@ export class JsonPatch<N extends JsonNode = JsonNode<any>> {
         this.strIns(op.path, op.pos, op.str);
         break;
       case 'str_del':
-        this.strDel(op.path, op.pos, op.len ?? 0, op.str);
+        this.strDel(op.path, op.pos, op.len ?? op.str?.length ?? 0, op.str);
         break;
       default:
         throw new Error('UNKNOWN_OP');

--- a/packages/json-joy/src/json-crdt/json-patch/__tests__/JsonPatch.str.spec.ts
+++ b/packages/json-joy/src/json-crdt/json-patch/__tests__/JsonPatch.str.spec.ts
@@ -73,6 +73,12 @@ const testCases: TestCase[] = [
     doc2: '',
   },
   {
+    name: 'can delete characters by value',
+    doc1: 'hello world!',
+    patches: [[{op: 'str_del', path: [], pos: 5, str: ' world'}]],
+    doc2: 'hello!',
+  },
+  {
     name: 'can delete from already empty string',
     doc1: '',
     patches: [[{op: 'str_del', path: [], pos: 0, len: 1}]],


### PR DESCRIPTION
## Problem

The JSON CRDT `JsonPatch` adapter accepts the value form of `str_del`, but when `len` is omitted it forwards a zero-length deletion. For example, deleting `" world"` at position 5 from `"hello world!"` leaves the model unchanged even though the public operation type, validator, and generic patcher support this form.

## Fix

Use the supplied string length when `len` is absent. Explicit `len` continues to take precedence.

## Tests

- `node .yarn/releases/yarn-4.12.0.cjs test packages/json-joy/src/json-crdt/json-patch` — 83 passed
- `node .yarn/releases/yarn-4.12.0.cjs test packages/json-joy/` — 9,430 passed, 3 skipped
- `node .yarn/releases/yarn-4.12.0.cjs format` — passed
- `node .yarn/releases/yarn-4.12.0.cjs lint` — passed
- `node .yarn/releases/yarn-4.12.0.cjs build` — passed
- `node .yarn/releases/yarn-4.12.0.cjs typecheck` — passed
- `node .yarn/releases/yarn-4.12.0.cjs vitest` — 2,134 passed, 4 unrelated E2E tests skipped
- `node .yarn/releases/yarn-4.12.0.cjs workspace json-joy build:esm` — passed
- `node .yarn/releases/yarn-4.12.0.cjs typedoc` — passed with warnings

## Compatibility

This changes only the previously ineffective `str`-only deletion form. Operations that provide `len` keep their existing behavior; there is no public type change.

## Related issue

No exact issue was found. This was independently reproduced on current `master`.
